### PR TITLE
:pencil2: fix typo

### DIFF
--- a/annotator_test.go
+++ b/annotator_test.go
@@ -41,7 +41,7 @@ func TestAnnotator(t *testing.T) {
 		}
 	}
 
-	dMatrix, err := treelite.CreaetFromMat(feature, nRow, nCol, float32(math.NaN()))
+	dMatrix, err := treelite.CreateFromMat(feature, nRow, nCol, float32(math.NaN()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dmatrix.go
+++ b/dmatrix.go
@@ -24,8 +24,8 @@ type DMatrix struct {
 	element int
 }
 
-// CreaetFromMat creates a dense DMatrix from the given data
-func CreaetFromMat(
+// CreateFromMat creates a dense DMatrix from the given data
+func CreateFromMat(
 	data []float32,
 	nrow, ncol int,
 	missing float32,

--- a/dmatrix_test.go
+++ b/dmatrix_test.go
@@ -14,7 +14,7 @@ func TestDMatrix_CreaetFromMat(t *testing.T) {
 	ncol := 3
 	nonZero := 6
 
-	target, err := treelite.CreaetFromMat(data, nrow, ncol, float32(math.NaN()))
+	target, err := treelite.CreateFromMat(data, nrow, ncol, float32(math.NaN()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,7 @@ import (
 func Example() {
 	data, nRow, nCol := loadData()
 
-	dMatrix, err := treelite.CreaetFromMat(data, nRow, nCol, float32(math.NaN()))
+	dMatrix, err := treelite.CreateFromMat(data, nRow, nCol, float32(math.NaN()))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/predictor_test.go
+++ b/predictor_test.go
@@ -66,7 +66,7 @@ func TestPredictor_PredictBatch(t *testing.T) {
 		}
 	}
 
-	dMatrix, err := treelite.CreaetFromMat(feature, nRow, nCol, float32(math.NaN()))
+	dMatrix, err := treelite.CreateFromMat(feature, nRow, nCol, float32(math.NaN()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Changed
- rename treelite.CreaetFromMat to treelite.CreateFromMat